### PR TITLE
[fix]QuestionShowからß削除

### DIFF
--- a/front/src/components/questions/QuestionShow.vue
+++ b/front/src/components/questions/QuestionShow.vue
@@ -34,7 +34,7 @@
           </section>
           <section class="text-3xl font-bold">{{ question.title }}</section>
           <section class="font-normal text-md text-gray-700">
-            {{ question.content }}ß
+            {{ question.content }}
           </section>
           <section class="font-normal text-md text-gray800">
             <ul></ul>


### PR DESCRIPTION
why
質問内容にßが追加される部分の修正

what
ß削除